### PR TITLE
Adding unit tests with service containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Update the VARIANT arg in devcontainer.json to pick a Python version: 3, 3.8, 3.7, 3.6 
+# To fully customize the contents of this image, use the following Dockerfile instead:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/python-3/.devcontainer/base.Dockerfile
+ARG VARIANT="3"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Optional] If your requirements rarely change, uncomment this section to add them to the image.
+#
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional packages.
+#
+# RUN apt-get update \
+#     && export DEBIAN_FRONTEND=noninteractive \
+#    && apt-get -y install --no-install-recommends <your-package-list-here>
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/python-3
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		// Update 'VARIANT' to pick a Python version. Rebuild the container 
+		// if it already exists to update. Available variants: 3, 3.6, 3.7, 3.8 
+		"args": { "VARIANT": "3" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,56 +1,50 @@
-# This is a basic workflow to help you get started with Actions
 
 name: CI-Tests
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  BuildTestContainer:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Build Test Image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: xinsnake
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          repository: xinsnake/databrick-install-lib-action-mocks
+          tags: ${{ github.sha }}
+          path: ./tests/mocks
+          always_pull: true
+  BuildActionContainer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Action Image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: xinsnake
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          repository: xinsnake/databrick-install-lib-action
+          tags: ${{ github.sha }}
+          path: .
+          always_pull: true
+  RunTest:
+    runs-on: ubuntu-latest
+    container: xinsnake/databrick-install-lib-action:${{ github.sha }}
+    needs: [BuildTestContainer, BuildActionContainer]
+    services:
+      mocks:
+        image: xinsnake/databrick-install-lib-action-mocks:${{ github.sha }}
+        ports: 
+          - 5000:5000
+    steps:
     - uses: actions/checkout@v2
-
-    - name: Build Test Image
-      uses: docker/build-push-action@v1.1.0
-      with:
-        # Docker repository to tag the image with
-        repository: databrick-install-lib-action-mocks
-        # Comma-delimited list of tags. These will be added to the registry/repository to form the image's tags
-        tags: latest
-        # Path to the build context
-        path: ./tests/mocks
-        # Always attempt to pull a newer version of the image
-        always_pull: true
-        # Whether to push the image
-        push: false
-
-    - name: Build Action Image
-      uses: docker/build-push-action@v1.1.0
-      with:
-        # Docker repository to tag the image with
-        repository: databrick-install-lib-action
-        # Comma-delimited list of tags. These will be added to the registry/repository to form the image's tags
-        tags: latest
-        # Path to the build context
-        path: .
-        # Always attempt to pull a newer version of the image
-        always_pull: true
-        # Whether to push the image
-        push: false
-        
     - name: Run Tests
       run: |
-        docker run --rm -p 5000:5000 databrick-install-lib-action-mocks:latest
-        docker run --rm databrick-install-lib-action:latest /entrypoint.sh "http://localhost:5000" "token123" "clusterid123" "lib01,lib02,lib03" "dbfs://somedir"
+        /entrypoint.sh "http://mocks:5000" "token123" "clusterid123" "lib01 lib02 lib03" "dbfs://somedir"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,4 +47,4 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Tests
       run: |
-        /entrypoint.sh "http://mocks:5000" "token123" "clusterid123" "lib01 lib02 lib03" "dbfs://somedir"
+        /entrypoint.sh "http://mocks:5000" "token123" "clusterid123" "lib01,lib02,lib03" "dbfs://somedir/"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,56 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI-Tests
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Build Test Image
+      uses: docker/build-push-action@v1.1.0
+      with:
+        # Docker repository to tag the image with
+        repository: databrick-install-lib-action-mocks
+        # Comma-delimited list of tags. These will be added to the registry/repository to form the image's tags
+        tags: latest
+        # Path to the build context
+        path: ./tests/mocks
+        # Always attempt to pull a newer version of the image
+        always_pull: true
+        # Whether to push the image
+        push: false
+
+    - name: Build Action Image
+      uses: docker/build-push-action@v1.1.0
+      with:
+        # Docker repository to tag the image with
+        repository: databrick-install-lib-action
+        # Comma-delimited list of tags. These will be added to the registry/repository to form the image's tags
+        tags: latest
+        # Path to the build context
+        path: .
+        # Always attempt to pull a newer version of the image
+        always_pull: true
+        # Whether to push the image
+        push: false
+        
+    - name: Run Tests
+      run: |
+        docker run --rm -p 5000:5000 databrick-install-lib-action-mocks:latest
+        docker run --rm databrick-install-lib-action:latest /entrypoint.sh "http://localhost:5000" "token123" "clusterid123" "lib01,lib02,lib03" "dbfs://somedir"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,151 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.7.5-slim
 
+COPY requirements.txt /requirements.txt
+RUN pip3 install -r /requirements.txt
+
 COPY entrypoint.sh /entrypoint.sh
 COPY installWhlLibrary.py /installWhlLibrary.py
-COPY requirements.txt /requirements.txt
-
-RUN pip3 install -r /requirements.txt
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-"# databrick-install-lib-action" 
+# GitHub action for installing libraries to  Databricks clusters
+
+This is a github action that will install custom libraries to Databricks clusters. The libraries need to be stored in DBFS path. 
+
+The implement of this action is based on the code and example in [Continuous integration and delivery on Databricks using Jenkins](https://docs.databricks.com/dev-tools/ci-cd/ci-cd-jenkins.html) 
+
+Here is a action workflow example.  
+
+```yaml
+name: Run Databicks Notebooks GitHub Install Library Action Demo 
+on: 
+  push:
+    branches: 
+      - master 
+jobs:
+  build-and-deploy: 
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Install WHL to the cluster
+      uses: Herman-Wu/databrick-install-lib-action@master
+      with:
+        databrick-server-uri: 'https://XXXX.XX.azuredatabricks.net'
+        databrick-token: ' <databrick-token> '
+        databrick-cluster-id: ' < databrick-cluster-id >'
+        databrick-libraries: ' XXXX.whl  YYYY.whl ZZZ.whl'
+        databrick-dbfs-path: 'dbfs:/mnt/XXXX/ '
+```
+
+
+<br>
+
+**Future Improvement**
+    - improve docker image preparation time

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Databrick Notebook Run'
-description: 'Run a notebook in Databrick'
+name: 'Install Libraries to Databrick Clusters'
+description: 'Install WHL into Databrick clusters'
 author: "Herman-Wu"
 inputs:
   databrick-server-uri: # id of input
@@ -19,14 +19,14 @@ inputs:
     required: true
     default: "XXX"
   databrick-dbfs-path: # id of input
-    description: 'Libraries for Databrick'
+    description: 'DBFS path to the libraries'
     required: true
     default: "YYYY"
 outputs:
   result: # id of output
     description: 'Installation result of the librarires'
 branding:
-  icon: "align-justify"
+  icon: "download-cloud"
   color: "red"
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,5 +17,3 @@ python3 ${SCRIPTPATH}/installWhlLibrary.py --workspace=${DBURL}\
                         --clusterid=${CLUSTERID}\
                         --libs=$LIBS\
                         --dbfspath=${DBFSPATH}
-
-echo "Install Libraries Done"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
 
-echo "Hello $1 $2 $3 $4 $5 "
+echo "Start Install WHL Libiraries with parameters $1 $2 $3 $4 $5 "
 time=$(date)
 echo ::set-output name=time::$time
 
@@ -10,21 +10,7 @@ CLUSTERID=$3
 LIBS=$4
 DBFSPATH=$5
 
-
-echo "Hello2 $DBURL $TOKEN $CLUSTERID $LIBS $DBFSPATH "
-
-echo "Run: python3 ${SCRIPTPATH}/installWhlLibrary.py --workspace=${DBURL}\
-                        --token=$TOKEN\
-                        --clusterid=${CLUSTERID}\
-                        --libs=$LIBS\
-                        --dbfspath=${DBFSPATH} "
-
-
-echo "Run: python3 ${SCRIPTPATH}/installWhlLibrary.py --workspace=${DBURL}\
-                        --token=$TOKEN\
-                        --clusterid=${CLUSTERID}\
-                        --libs=$LIBS\
-                        --dbfspath=${DBFSPATH} "
+echo "Install WHL Libiraries with parameters $DBURL $TOKEN $CLUSTERID $LIBS $DBFSPATH "
 
 python3 ${SCRIPTPATH}/installWhlLibrary.py --workspace=${DBURL}\
                         --token=$TOKEN\

--- a/tests/mocks/Dockerfile
+++ b/tests/mocks/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:slim
 
 RUN mkdir -p /app
-COPY ./*.py requirements.txt entrypoint.sh /app/
+
+COPY requirements.txt /app/
 RUN pip3 install -r /app/requirements.txt
 
+COPY *.py requirements.txt entrypoint.sh /app/
 RUN chmod u+x /app/entrypoint.sh
 EXPOSE 5000
 

--- a/tests/mocks/Dockerfile
+++ b/tests/mocks/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:slim
+
+RUN mkdir -p /app
+COPY ./*.py requirements.txt entrypoint.sh /app/
+RUN pip3 install -r /app/requirements.txt
+
+RUN chmod u+x /app/entrypoint.sh
+EXPOSE 5000
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/tests/mocks/app.py
+++ b/tests/mocks/app.py
@@ -1,0 +1,72 @@
+from flask import Flask
+from flask import request
+import json
+
+from .databricksCluster import MockDBCluster
+
+app = Flask(__name__)
+clusters = {}
+
+def get_cluster():
+  cluster_id = request.args.get('cluster_id', '')
+  if cluster_id == '':
+    body = request.get_json()
+    if (body and 'cluster_id' in body):
+      cluster_id = body['cluster_id']
+    else:
+      return None
+
+  if cluster_id == '':
+    return None
+
+  if not (cluster_id in clusters):
+    clusters[cluster_id] = MockDBCluster(cluster_id, 'PENDING', [])
+
+  return clusters.get(cluster_id)
+
+def get_libraries():
+  body = request.get_json()
+  if (body and 'libraries' in body):
+    return body['libraries']
+  else:
+    return None
+
+@app.route('/api/2.0/libraries/uninstall', methods=['POST'])
+def libraries_uninstall():
+  cluster = get_cluster()
+  libraries = get_libraries()
+  if cluster is None or libraries is None:
+    return ('', 400)
+  cluster.uninstall_library(libraries)
+  return {}
+
+@app.route('/api/2.0/libraries/install', methods=['POST'])
+def libraries_install():
+  cluster = get_cluster()
+  libraries = get_libraries()
+  if cluster is None or libraries is None:
+    return ('', 400)
+  cluster.install_library(libraries)
+  return {}
+
+@app.route('/api/2.0/libraries/cluster-status')
+def libraries_clusterstatus():
+  cluster = get_cluster()
+  if cluster is None:
+    return ('', 400)
+  return {'library_statuses': cluster.get_library_statuses()}
+
+@app.route('/api/2.0/clusters/restart', methods=['POST'])
+def clusters_restart():
+  cluster = get_cluster()
+  if cluster is None:
+    return ('', 400)
+  cluster.restart_cluster(10)
+  return {}
+
+@app.route('/api/2.0/clusters/get')
+def clusters_get():
+  cluster = get_cluster()
+  if cluster is None:
+    return ('', 400)
+  return {'status': cluster.get_status()}

--- a/tests/mocks/app.py
+++ b/tests/mocks/app.py
@@ -20,7 +20,7 @@ def get_cluster():
     return None
 
   if not (cluster_id in clusters):
-    clusters[cluster_id] = MockDBCluster(cluster_id, 'PENDING', [])
+    clusters[cluster_id] = MockDBCluster(cluster_id, 'RUNNING', [{'whl': 'dbfs://somedir/lib01'}])
 
   return clusters.get(cluster_id)
 
@@ -69,4 +69,4 @@ def clusters_get():
   cluster = get_cluster()
   if cluster is None:
     return ('', 400)
-  return {'status': cluster.get_status()}
+  return {'state': cluster.get_status()}

--- a/tests/mocks/databricksCluster.py
+++ b/tests/mocks/databricksCluster.py
@@ -11,6 +11,7 @@ class MockDBCluster:
     self.__cluster_id = cluster_id
     self.__current_state = init_state
     self.__installed_libraries = init_libraries
+    self.__installed_libraries_after_restart = init_libraries
 
   def __isInstalled(self, library):
     for l in self.__installed_libraries:
@@ -34,12 +35,12 @@ class MockDBCluster:
   def get_library_statuses(self):
     libs = []
     for l in self.__installed_libraries:
-      libs.append({'library': l, 'status': 'installed'})
+      libs.append({'library': l, 'status': 'INSTALLED'})
     return libs
 
   def uninstall_library(self, libraries):
     for library in libraries:
-      if self.__isInstalled(library):
+      if self.__isInstalledAfterRestart(library):
         self.__installed_libraries_after_restart.remove(library)
 
   def get_status(self):

--- a/tests/mocks/databricksCluster.py
+++ b/tests/mocks/databricksCluster.py
@@ -1,0 +1,56 @@
+import time
+
+class MockDBCluster:
+  __cluster_id = 0
+  __current_state = ''
+  __installed_libraries = []
+  __installed_libraries_after_restart = []
+  __state_running_from = 0
+
+  def __init__(self, cluster_id, init_state, init_libraries):
+    self.__cluster_id = cluster_id
+    self.__current_state = init_state
+    self.__installed_libraries = init_libraries
+
+  def __isInstalled(self, library):
+    for l in self.__installed_libraries:
+      if l == library:
+        return True
+    return False
+
+  def __isInstalledAfterRestart(self, library):
+    for l in self.__installed_libraries_after_restart:
+      if l == library:
+        return True
+    return  False
+
+  def install_library(self, libraries):
+    for library in libraries:
+      if not self.__isInstalled(library):
+        self.__installed_libraries.append(library)
+      if not self.__isInstalledAfterRestart(library):
+        self.__installed_libraries_after_restart.append(library)
+
+  def get_library_statuses(self):
+    libs = []
+    for l in self.__installed_libraries:
+      libs.append({'library': l, 'status': 'installed'})
+    return libs
+
+  def uninstall_library(self, libraries):
+    for library in libraries:
+      if self.__isInstalled(library):
+        self.__installed_libraries_after_restart.remove(library)
+
+  def get_status(self):
+    current_ts = time.time()
+    if (current_ts > self.__state_running_from):
+      self.__current_state = 'RUNNING'
+    else:
+      self.__current_state = 'PENDING'
+    return self.__current_state
+
+  def restart_cluster(self, restart_takes_seconds):
+    self.__current_state = 'PENDING'
+    self.__installed_libraries = self.__installed_libraries_after_restart.copy()
+    self.__state_running_from = time.time() + restart_takes_seconds

--- a/tests/mocks/entrypoint.sh
+++ b/tests/mocks/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -l
+
+export FLASK_ENV=development
+
+cd /app && /usr/local/bin/flask run --host=0.0.0.0

--- a/tests/mocks/requirements.txt
+++ b/tests/mocks/requirements.txt
@@ -1,0 +1,6 @@
+click==7.1.2
+Flask==1.1.2
+itsdangerous==1.1.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+Werkzeug==1.0.1


### PR DESCRIPTION
Hi @Herman-Wu , there are a few things I changed there:

- Adding `.devcontainer` folder for a Python container for development.
- Adding `.gitignore` file.
- Adding `.github` folder to include workflows.
- Adding `tests` folder to include a Flask application container.
- Modified the action's `Dockerfile` to utilise container build cache.
- Removed `echo` in the `entrypoint.sh` so the exit code from Python is able to fail the workflow.
- Changes in logging in the action for debugging and diagnosis.
- Minor fixes and improvements
  - Replace `request.post` `data` to be `json` so the headers are set automatically.
  - Split to add "," so it is not space separated by default.
  - Fix getLibStatus so when there are more than one libraries it doesn't always return "not found".