### PR TITLE
Improvements on the container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.5-slim
+FROM python:slim
 
 COPY requirements.txt /requirements.txt
 RUN pip3 install -r /requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 requests
-databricks-connect
-databricks-cli
-pytest


### PR DESCRIPTION
Hi Herman,

I've made 2 changes in this PR:

- Always use the latest python:slim to make sure we are on the latest software versions
- Remove unused requirements to reduce the container size from 900MB+ to around 70MB.

Thanks!
Jacob